### PR TITLE
Merge from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+### This project is looking for a maintainer. As much as I love the language, ecosystem, community around Elixir, I'm not currently lucky enough to be doing any serious work in the language. If someone would like to take some responsibility for the project I would hugely appreciate it.
+
 # Bugsnag Elixir
 
 Capture exceptions and send them to the [Bugsnag](http://bugsnag.com) API!

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ defp deps do
   [{:bugsnag, "~> 1.0.0"}]
 end
 
+# Now, list the :bugsnag application as your application dependency:
+def application do
+  [applications: [:bugsnag]]
+end
+
 # Open up your config/config.exs (or appropriate project config)
 config :bugsnag, api_key: "bbf085fc54ff99498ebd18ab49a832dd"
 ```
@@ -17,9 +22,6 @@ config :bugsnag, api_key: "bbf085fc54ff99498ebd18ab49a832dd"
 ## Usage
 
 ```elixir
-# Turn the lights on.
-Bugsnag.start
-
 # Report an exception.
 try do
   :foo = :bar

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -47,7 +47,7 @@ defmodule Bugsnag.Payload do
   defp add_context(event, nil), do: event
   defp add_context(event, context), do: Map.put(event, :context, context)
 
-  defp add_user(event, nil), do: Event
+  defp add_user(event, nil), do: event
   defp add_user(event, user), do: Map.put(event, :user, user)
 
   defp add_env(event), do: Map.put(event, :app, %{releaseStage: Mix.env})

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -64,9 +64,8 @@ defmodule Bugsnag.Payload do
           method: Exception.format_mfa(module, function, args)
         }
       ({ module, function, args, [file: file, line: line_number] }) ->
-        file = List.to_string file
         %{
-          file: file,
+          file: List.to_string(file),
           lineNumber: line_number,
           inProject: String.starts_with?(file, "web"),
           method: Exception.format_mfa(module, function, args),

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -26,6 +26,7 @@ defmodule Bugsnag.Payload do
       |> add_severity(Keyword.get(options, :severity))
       |> add_context(Keyword.get(options, :context))
       |> add_user(Keyword.get(options, :user))
+      |> add_metadata(Keyword.get(options, :metadata))
       |> add_env
 
     Map.put payload, :events, [event]
@@ -49,6 +50,9 @@ defmodule Bugsnag.Payload do
 
   defp add_user(event, nil), do: event
   defp add_user(event, user), do: Map.put(event, :user, user)
+
+  defp add_metadata(event, nil), do: event
+  defp add_metadata(event, metadata), do: Map.put(event, :metaData, metadata)
 
   defp add_env(event), do: Map.put(event, :app, %{releaseStage: Mix.env})
 

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -77,9 +77,10 @@ defmodule Bugsnag.Payload do
   end
 
   defp get_file_contents(file, line_number) do
-    if String.starts_with? file, "web" do
-      File.cwd!
-      |> Path.join(file)
+    file = File.cwd! |> Path.join(file)
+
+    if File.exists?(file) do
+      file
       |> File.stream!
       |> Stream.with_index
       |> Stream.map(fn({line, index}) -> {to_string(index + 1), line} end)

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -10,10 +10,7 @@ defmodule Bugsnag.Payload do
   def new(exception, stacktrace, options) do
     %__MODULE__{}
     |> add_api_key
-    |> add_event(exception,
-                 stacktrace,
-                 Keyword.get(options, :context),
-                 Keyword.get(options, :severity))
+    |> add_event(exception, stacktrace, options)
   end
 
   defp add_api_key(payload) do
@@ -21,12 +18,16 @@ defmodule Bugsnag.Payload do
     |> Map.put :apiKey, Application.get_env(:bugsnag, :api_key)
   end
 
-  defp add_event(payload, exception, stacktrace, context, severity) do
-    event = %{}
-    |> add_payload_version
-    |> add_exception(exception, stacktrace)
-    |> add_severity(severity)
-    |> add_context(context)
+  defp add_event(payload, exception, stacktrace, options) do
+    event =
+      %{}
+      |> add_payload_version
+      |> add_exception(exception, stacktrace)
+      |> add_severity(Keyword.get(options, :severity))
+      |> add_context(Keyword.get(options, :context))
+      |> add_user(Keyword.get(options, :user))
+      |> add_env
+
     Map.put payload, :events, [event]
   end
 
@@ -46,29 +47,40 @@ defmodule Bugsnag.Payload do
   defp add_context(event, nil), do: event
   defp add_context(event, context), do: Map.put(event, :context, context)
 
+  defp add_user(event, nil), do: Event
+  defp add_user(event, user), do: Map.put(event, :user, user)
+
+  defp add_env(event), do: Map.put(event, :app, %{releaseStage: Mix.env})
+
   defp format_stacktrace(stacktrace) do
     Enum.map stacktrace, fn
       ({ module, function, args, [] }) ->
         %{
           file: "unknown",
           lineNumber: 0,
-          method: "#{ module }.#{ function }#{ format_args(args) }"
+          method: Exception.format_mfa(module, function, args)
         }
       ({ module, function, args, [file: file, line: line_number] }) ->
+        file = List.to_string file
         %{
-          file: file |> List.to_string,
+          file: file,
           lineNumber: line_number,
-          method: "#{ module }.#{ function }#{ format_args(args) }"
+          inProject: String.starts_with?(file, "web"),
+          method: Exception.format_mfa(module, function, args),
+          code: get_file_contents(file, line_number)
         }
     end
   end
 
-  defp format_args(args) when is_integer(args) do
-    "/#{args}"
-  end
-  defp format_args(args) when is_list(args) do
-    "(#{args
-        |> Enum.map(&(inspect(&1)))
-        |> Enum.join(", ")})"
+  defp get_file_contents(file, line_number) do
+    if String.starts_with? file, "web" do
+      File.cwd!
+      |> Path.join(file)
+      |> File.stream!
+      |> Stream.with_index
+      |> Stream.map(fn({line, index}) -> {to_string(index + 1), line} end)
+      |> Enum.slice(if(line_number - 4 > 0, do: line_number - 4, else: 0), 7)
+      |> Enum.into(%{})
+    end
   end
 end

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -64,10 +64,11 @@ defmodule Bugsnag.Payload do
           method: Exception.format_mfa(module, function, args)
         }
       ({ module, function, args, [file: file, line: line_number] }) ->
+        file = to_string file
         %{
-          file: List.to_string(file),
+          file: file,
           lineNumber: line_number,
-          inProject: String.starts_with?(file, "web"),
+          inProject: Regex.match?(~r/^(lib|web)/, file),
           method: Exception.format_mfa(module, function, args),
           code: get_file_contents(file, line_number)
         }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bugsnag.Mixfile do
   def project do
     [app: :bugsnag,
      version: "1.1.1",
-     elixir: "~> 1.0",
+     elixir: "~> 1.2",
      package: package,
      description: """
        An Elixir interface to the Bugsnag API

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bugsnag.Mixfile do
   def project do
     [app: :bugsnag,
      version: "1.1.1",
-     elixir: "~> 1.0.2",
+     elixir: "~> 1.0",
      package: package,
      description: """
        An Elixir interface to the Bugsnag API
@@ -19,7 +19,7 @@ defmodule Bugsnag.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [applications: [:httpoison]]
   end
 
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Bugsnag.Mixfile do
 
   def project do
     [app: :bugsnag,
-     version: "1.1.1",
+     version: "1.2.0",
      elixir: "~> 1.0",
      package: package,
      description: """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bugsnag.Mixfile do
   def project do
     [app: :bugsnag,
      version: "1.1.1",
-     elixir: "~> 1.2",
+     elixir: "~> 1.0",
      package: package,
      description: """
        An Elixir interface to the Bugsnag API

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -40,20 +40,22 @@ defmodule Bugsnag.PayloadTest do
   end
 
   test "it generates correct stacktraces" do
-    {exception, stacktrace} = try do
-      Enum.join(3, 'million')
-    rescue
-      exception -> {exception, System.stacktrace}
-    end
+    {exception, stacktrace} =
+      try do
+        Enum.join(3, 'million')
+      rescue
+        exception -> {exception, System.stacktrace}
+      end
+
     %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} = Payload.new(exception, stacktrace, [])
     assert [%{file: "lib/enum.ex", lineNumber: _, method: _},
-            %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: "Elixir.Bugsnag.PayloadTest.test it generates correct stacktraces/1"}
+            %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: ~s(Bugsnag.PayloadTest."test it generates correct stacktraces"/1)}
             | _] = stacktrace
   end
 
   test "it generates correct stacktraces when the current file was a script" do
     assert [%{file: "unknown", lineNumber: 0, method: _},
-            %{file: "test/bugsnag/payload_test.exs", lineNumber: 9, method: "Elixir.Bugsnag.PayloadTest.get_problem/0"},
+            %{file: "test/bugsnag/payload_test.exs", lineNumber: 9, method: "Bugsnag.PayloadTest.get_problem/0"},
             %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: _} | _] = get_exception.stacktrace
   end
 
@@ -65,8 +67,8 @@ defmodule Bugsnag.PayloadTest do
       exception -> {exception, System.stacktrace}
     end
     %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} = Payload.new(exception, stacktrace, [])
-    assert [%{file: "unknown", lineNumber: 0, method: "Elixir.Fart.poo(:butts, 1, \"foo\\n\")"},
-            %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: _} | _] = stacktrace
+    assert [%{file: "unknown", lineNumber: 0, method: "Fart.poo(:butts, 1, \"foo\\n\")"},
+            %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: _, code: _} | _] = stacktrace
   end
 
   test "it reports the error class" do
@@ -74,7 +76,7 @@ defmodule Bugsnag.PayloadTest do
   end
 
   test "it reports the error message" do
-    assert "undefined function: Harbour.cats/1 (module Harbour is not available)" == get_exception.message
+    assert "undefined function Harbour.cats/1 (module Harbour is not available)" == get_exception.message
   end
 
   test "it reports the error severity" do
@@ -85,10 +87,10 @@ defmodule Bugsnag.PayloadTest do
   end
 
   test "it reports the release stage" do
-    assert "production" == get_event.app.releaseStage
+    assert "test"    == get_event.app.releaseStage
     assert "staging" == get_event(release_stage: "staging").app.releaseStage
-    assert "qa" == get_event(release_stage: "qa").app.releaseStage
-    assert "" == get_event(release_stage: "").app.releaseStage
+    assert "qa"      == get_event(release_stage: "qa").app.releaseStage
+    assert ""        == get_event(release_stage: "").app.releaseStage
   end
 
   test "it reports the payload version" do


### PR DESCRIPTION
The latest pull requests (one of them from May 2015...) merged into the original project have a pretty nice feature, apart from other improvements, that could be handy for us: show the code snippet where the exception was raised inside Bugsnag.

PS: We need to keep this fork to make use of `custom_stacktrace` due to our consumer design. The project is still looking for maintainers. Shall we?
